### PR TITLE
ZCS-8017: updating guava version to 28.1-jre from 23.0 and centrally

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -11,7 +11,7 @@
   <dependency org="xerces" name="xercesImpl" rev="2.9.1-patch-01"/>
   <dependency org="log4j" name="log4j" rev="1.2.16" />
   <dependency org="org.json" name="json" rev="20090211" />
-  <dependency org="com.google.guava" name="guava" rev="23.0" />
+  <dependency org="com.google.guava" name="guava" rev="${com.google.guava.version}" />
   <dependency org="commons-httpclient" name="commons-httpclient" rev="3.1" />
   <dependency org="zimbra" name="zm-common" rev="latest.integration"/>
   <dependency org="zimbra" name="zm-soap" rev="latest.integration" />


### PR DESCRIPTION
Issue:
Vulnerabilities in older version 23.0 of Guava.

Fix:
Update version to 28.1-jre and make it available centrally